### PR TITLE
Ideas for additional content

### DIFF
--- a/BlazorHtmx/BlazorHtmx.csproj
+++ b/BlazorHtmx/BlazorHtmx.csproj
@@ -13,4 +13,8 @@
       </Content>
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Htmx" Version="1.8.0" />
+    </ItemGroup>
+
 </Project>

--- a/BlazorHtmx/Components/App.razor
+++ b/BlazorHtmx/Components/App.razor
@@ -1,4 +1,12 @@
-﻿<!DOCTYPE html>
+﻿@inject IHtmxContext Htmx
+
+@if ( Htmx.IsHtmx )
+{
+    <Routes />
+    return;
+}
+
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -11,7 +19,7 @@
     <link rel="icon" type="image/png" href="favicon.png"/>
 
     <script defer src="_framework/blazor.web.js"></script>
-    <script defer src="https://unpkg.com/htmx.org@1.9.8"></script>
+    <script defer src="https://unpkg.com/htmx.org@2.0.0"></script>
     <script defer src="js/htmx-blazor.js"></script>
     <HeadOutlet/>
 </head>

--- a/BlazorHtmx/Components/Htmx/HtmxContext.cs
+++ b/BlazorHtmx/Components/Htmx/HtmxContext.cs
@@ -1,0 +1,14 @@
+using Htmx;
+
+namespace BlazorHtmx.Components.Htmx;
+
+public class HtmxContext : IHtmxContext, IMiddleware
+{
+    public bool IsHtmx { get; private set; }
+    
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        IsHtmx = context.Request.IsHtmx();
+        await next(context);
+    }
+}

--- a/BlazorHtmx/Components/Htmx/IHtmxContext.cs
+++ b/BlazorHtmx/Components/Htmx/IHtmxContext.cs
@@ -1,0 +1,6 @@
+namespace BlazorHtmx.Components.Htmx;
+
+public interface IHtmxContext
+{
+    bool IsHtmx { get; }
+}

--- a/BlazorHtmx/Components/Layout/MainLayout.razor
+++ b/BlazorHtmx/Components/Layout/MainLayout.razor
@@ -1,4 +1,11 @@
 ﻿@inherits LayoutComponentBase
+@inject IHtmxContext Htmx
+
+@if ( Htmx.IsHtmx )
+{
+    @Body
+    return;
+}
 
 <div class="page">
     <div class="sidebar">

--- a/BlazorHtmx/Components/Pages/Home.razor
+++ b/BlazorHtmx/Components/Pages/Home.razor
@@ -9,12 +9,30 @@
     <HtmxCounter State="CounterState"/>
 </div>
 
-<div>
+<div class="mb-4">
+    <LoveHtmx Message="I ❤️ Components"></LoveHtmx>    
+</div>
+
+<div class="mb-4">
     <button class="btn btn-primary"
             hx-swap="outerHTML"
             hx-get="/love-htmx">
         Click Me For Blazor + HTMX
     </button>
+</div>
+
+<div class="mb-4">
+    <button class="btn btn-primary"
+            hx-swap="outerHTML"
+            hx-get="/love-mbc">
+        Click Me For MBC + HTMX
+    </button>
+</div>
+
+<div class="mb-4">
+    <a href="/love-htmx" class="btn btn-primary">
+        Click Me For Blazor SSR
+    </a>
 </div>
 
 @code {

--- a/BlazorHtmx/Components/Shared/LoveHtmx.razor
+++ b/BlazorHtmx/Components/Shared/LoveHtmx.razor
@@ -1,3 +1,8 @@
+@page "/love-htmx"
+@inject IHtmxContext Htmx
+
+<title>I ❤️ Blazor</title>
+
 <div class="alert alert-info">
     <span class="text-lg-center">
         @Message
@@ -6,5 +11,10 @@
 
 @code{
     [Parameter]
-    public string? Message { get; set; } = "I ❤️ HTMX";
+    public string? Message { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        Message ??= Htmx.IsHtmx ? "I ❤️ HTMX" : "I ❤️ Blazor";
+    }
 }

--- a/BlazorHtmx/Components/Shared/LoveMbc.cs
+++ b/BlazorHtmx/Components/Shared/LoveMbc.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BlazorHtmx.Components.Shared;
+
+public class LoveMbc : ControllerBase
+{
+    [Route("/love-mbc")]
+    public IResult OnGet() => new RazorComponentResult<LoveHtmx>(new { Message = "I ❤️ ASP.NET Core" });
+}

--- a/BlazorHtmx/Components/_Imports.razor
+++ b/BlazorHtmx/Components/_Imports.razor
@@ -8,4 +8,5 @@
 @using Microsoft.JSInterop
 @using BlazorHtmx
 @using BlazorHtmx.Components
+@using BlazorHtmx.Components.Htmx
 @using BlazorHtmx.Components.Shared

--- a/BlazorHtmx/Program.cs
+++ b/BlazorHtmx/Program.cs
@@ -1,4 +1,5 @@
 using BlazorHtmx.Components;
+using BlazorHtmx.Components.Htmx;
 using BlazorHtmx.Components.Shared;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -10,6 +11,11 @@ builder.Services.AddRazorComponents()
 
 builder.Services
     .AddSingleton<HtmxCounter.HtmxCounterState>();
+
+builder.Services.AddControllers();
+
+builder.Services.AddScoped<HtmxContext>();
+builder.Services.AddScoped<IHtmxContext>(sp => sp.GetRequiredService<HtmxContext>());
 
 var app = builder.Build();
 
@@ -25,13 +31,12 @@ app.UseHttpsRedirection();
 
 app.UseStaticFiles();
 app.UseAntiforgery();
+app.UseMiddleware<HtmxContext>();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
-app.MapGet("/love-htmx",
-    () => new RazorComponentResult<LoveHtmx>(new { Message = "I ❤️ ASP.NET Core" }));
-
+app.MapControllers();
 
 app.MapPost("/count",
     (HtmxCounter.HtmxCounterState value) =>


### PR DESCRIPTION
Contributing back a few things I've learned along the way using Blazor Static SSR with HTMX.

I added a middleware to check whether we are in an HTMX request. Since this project has some server interactivity, I felt that was safer than trying to use IHttpContextAccessor.

`App.razor` and `MainLayout.razor` now short-circuit to avoid a complete render during HTMX requests. This allows `LoveHtmx.razor` to be routable rather than needing an API call.

I've found that the syntax of writing minimal APIs gets a bit clunky, particularly when capturing form data. I added an example of using a Controller with a RazorComonentResult, which I am affectionately dubbing "Model-Blazor-Controller". 

This results in demonstrating four ways to call the LoveHtmx component:
- As a component
- Static SSR
- HTMX via the same route
- As a controller action

I also bumped HTMX to 2.0 while listening to the [upgrade music](https://v2-0v2-0.htmx.org/migration-guide-htmx-1/#upgrade-music)